### PR TITLE
Improved error handling.

### DIFF
--- a/src/main/java/cc/bitbank/Bitbankcc.java
+++ b/src/main/java/cc/bitbank/Bitbankcc.java
@@ -65,6 +65,7 @@ import cc.bitbank.exception.BitbankException;
  * Created by tanaka on 2017/04/10.
  */
 public class Bitbankcc {
+    private static final int SUCCESS = 1;
     private String apiKey = "";
     private String apiSecret = "";
     private String endPointPublic;
@@ -154,7 +155,7 @@ public class Bitbankcc {
 
             JsonDecorder decorder = new JsonDecorder();
             T result = decorder.decode(json, clazz);
-            if (result == null) {
+            if (result == null || result.success != SUCCESS) {
                 ErrorCodeResponse error = decorder.decode(json, ErrorCodeResponse.class);
                 throw new BitbankException(error.data.code);
             } else {

--- a/src/main/java/cc/bitbank/entity/Depth.java
+++ b/src/main/java/cc/bitbank/entity/Depth.java
@@ -38,6 +38,11 @@ public class Depth extends Data {
 
     @Override
     public String toString() {
-        return "[Depth] " + "ask " + this.asks[0][0] + ", ... bids " + this.bids[0][0] + ", timestamp " + this.timestamp.getTime();
+        return "[Depth] " + "ask " + extract(asks) + ", ... bids " + extract(bids) + ", timestamp " + (timestamp == null ? null : timestamp.getTime());
     }
+
+    private <T> T extract(T[][] input) {
+        return input == null ? null : input.length == 0 ? null : input[0] == null ? null : input[0].length == 0 ? null : input[0][0];
+    }
+
 }

--- a/src/main/java/cc/bitbank/entity/Order.java
+++ b/src/main/java/cc/bitbank/entity/Order.java
@@ -36,7 +36,7 @@ public class Order extends Data {
     public String status;
 
     public String toString() {
-        return "[Order] orderId " + orderId + ", pair " + pair + ", side " + side.getCode() + ", type " + type +
+        return "[Order] orderId " + orderId + ", pair " + pair + ", side " + side + ", type " + type +
                 ", remainingAmount " + remainingAmount + ", price " + price + ", status " + status;
     }
 }

--- a/src/main/java/cc/bitbank/entity/Transactions.java
+++ b/src/main/java/cc/bitbank/entity/Transactions.java
@@ -27,8 +27,8 @@ public class Transactions extends Data {
         private Date executedAt;
 
         public String toString() {
-            return "[Transaction] transaction_id " + transactionId + ", side " + side.getCode() + ", price " + price + ", amount " +
-                    amount + ", executed_at " + executedAt.toString();
+            return "[Transaction] transaction_id " + transactionId + ", side " + side + ", price " + price + ", amount " +
+                    amount + ", executed_at " + executedAt;
         }
 
         public Long getTransactionId() {

--- a/src/main/java/cc/bitbank/exception/BitbankException.java
+++ b/src/main/java/cc/bitbank/exception/BitbankException.java
@@ -5,23 +5,33 @@ package cc.bitbank.exception;
  */
 public class BitbankException extends Exception {
 
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = -668176882481871028L;
+    /**
+     *
+     */
+    private static final long serialVersionUID = -668176882481871028L;
 
-	public int code;
+    public static final int DEFAULT_CODE = 0;
+
+    public final int code;
 
     public BitbankException() {
-        super();
-        this.code = 0;
+        this(DEFAULT_CODE);
     }
 
     public BitbankException(int code) {
-        this.code = code;
+        this(code, String.valueOf(code));
     }
 
     public BitbankException(String message) {
-        super(message);
+        this(DEFAULT_CODE, message);
     }
+
+    public BitbankException(int code, String message) {
+
+        super(message);
+
+        this.code = code;
+
+    }
+
 }


### PR DESCRIPTION
Improved error handling when an order cancellation fails. (cf: Trying to cancel an non-existent order).
* `Response#success` flag needs to be checked. Otherwise the failure is silently ignored, and returns an empty data.
* Avoid `NullPointerException` in `toString` methods.
* It wold be helpful to have the error code included in the exception's message rather than leaving it empty.